### PR TITLE
Wallet and market currency icons are fixed

### DIFF
--- a/web/src/components/Image/index.js
+++ b/web/src/components/Image/index.js
@@ -12,6 +12,8 @@ const Image = ({
 	imageWrapperClassName,
 	svgWrapperClassName,
 	stringId,
+	width,
+	height,
 	showUpload,
 	beforeInjection = () => {},
 }) => {
@@ -26,7 +28,7 @@ const Image = ({
 					'background-size-contain',
 					'h-100'
 				)}
-				style={{ backgroundImage: `url(${icon})` }}
+				style={{ backgroundImage: `url(${icon})`, width, height }}
 			/>
 		);
 	}
@@ -37,11 +39,17 @@ const Image = ({
 				<ReactSVG
 					src={icon}
 					className={classnames(wrapperClassName, svgWrapperClassName)}
+					style={{
+						width,
+						height,
+					}}
 					beforeInjection={beforeInjection}
 					fallback={() => (
 						<img
 							src={icon}
 							alt={alt}
+							width={width}
+							height={height}
 							className={classnames(wrapperClassName, svgWrapperClassName)}
 						/>
 					)}
@@ -51,6 +59,10 @@ const Image = ({
 				<img
 					src={icon}
 					alt={alt}
+					style={{
+						width,
+						height,
+					}}
 					className={classnames(
 						wrapperClassName,
 						imageWrapperClassName,

--- a/web/src/containers/TradeTabs/components/MarketRow.js
+++ b/web/src/containers/TradeTabs/components/MarketRow.js
@@ -26,6 +26,8 @@ class MarketRow extends Component {
 				<td className="sticky-col">
 					<div className="d-flex align-items-center">
 						<Image
+							width='32px'
+							height='32px'
 							iconId={icon_id}
 							icon={ICONS[icon_id]}
 							wrapperClassName="market-list__coin-icons"

--- a/web/src/containers/Wallet/CurrencyWallet.js
+++ b/web/src/containers/Wallet/CurrencyWallet.js
@@ -74,6 +74,8 @@ class Wallet extends Component {
 						iconId={icon_id}
 						icon={ICONS[icon_id]}
 						wrapperClassName="coin-icons"
+						width='32px'
+						height='32px'
 						imageWrapperClassName="currency-ball-image-wrapper"
 					/>
 					<div className="with_price-block_amount-value">


### PR DESCRIPTION
Bug Report: https://www.notion.so/hollaex/icon-size-for-coins-0b08c1efa32b44eaa5a8dad1a7512bcc

Icons are Aligned: 
![image](https://user-images.githubusercontent.com/36271003/185562360-3db67a74-dca9-4450-98fa-b070a1304693.png)
