### PR TITLE
generate-referrel-code-server

### DIFF
--- a/server/api/controllers/user.js
+++ b/server/api/controllers/user.js
@@ -1506,6 +1506,32 @@ const updateUserAddresses = (req, res) => {
 		});
 };
 
+const generateUserAffiliationCode = (req, res) => {
+	loggerUser.info(
+		req.uuid,
+		'controllers/user/generateUserAffiliationCode',
+	);
+	try {
+		const characters =
+		'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+		let code = '';
+
+		for (let i = 0; i < 6; i++) {
+			const randomIndex = Math.floor(Math.random() * characters.length);
+			code += characters[randomIndex];
+		}
+		
+		return res.json({ code });
+	} catch (err) {
+		loggerUser.error(
+			req.uuid,
+			'controllers/user/generateUserAffiliationCode err',
+			err.message
+		);
+		return res.status(err.statusCode || 400).json({ message: errorMessageConverter(err) });
+	}
+}
+
 
 module.exports = {
 	signUpUser,
@@ -1546,5 +1572,6 @@ module.exports = {
 	createUserReferralCode,
 	getUserReferralCodes,
 	updateUserAddresses,
-	fetchUserAddressBook
+	fetchUserAddressBook,
+	generateUserAffiliationCode
 };

--- a/server/api/swagger/user.yaml
+++ b/server/api/swagger/user.yaml
@@ -1628,6 +1628,34 @@ paths:
         - bearer
       x-security-scopes:
         - user
+  /user/referral/generate:
+    x-swagger-router-controller: user
+    get:
+      description: generate random affiliation code for user
+      operationId: generateUserAffiliationCode
+      tags:
+        - User
+      responses:
+        200:
+          description: Success
+          schema:
+            $ref: "#/definitions/ObjectResponse"
+        202:
+          description: CSV
+          schema:
+            type: string
+        default:
+          description: Error
+          schema:
+            $ref: "#/definitions/MessageResponse"
+      security:
+        - Token: []
+      x-security-types:
+        - bearer
+      x-security-scopes:
+        - user
+      x-token-permissions:
+        - can_read
   /user/referral/unrealized:
     x-swagger-router-controller: user
     get:

--- a/web/src/containers/Summary/components/ReferralList.js
+++ b/web/src/containers/Summary/components/ReferralList.js
@@ -25,6 +25,7 @@ import {
 	fetchReferralCodes,
 	postSettleFees,
 	fetchRealizedFeeEarnings,
+	generateReferralCode,
 } from './actions';
 import { Table } from 'components';
 import { getUserReferrals } from 'actions/userAction';
@@ -1522,8 +1523,8 @@ const ReferralList = ({
 													onClick={async () => {
 														if (!referralCode) {
 															try {
-																const code = generateUniqueCode();
-																setReferralCode(code);
+																const data = await generateReferralCode();
+																setReferralCode(data.code);
 																setDisplayCreateLink(true);
 															} catch (error) {
 																showErrorMessage(error.data.message);
@@ -1558,8 +1559,9 @@ const ReferralList = ({
 												onClick={async () => {
 													if (!referralCode) {
 														try {
-															const code = generateUniqueCode();
-															setReferralCode(code);
+															const data = await generateReferralCode();
+															setReferralCode(data.code);
+
 															setDisplayCreateLink(true);
 														} catch (error) {
 															showErrorMessage(error.data.message);


### PR DESCRIPTION
the problem with the server-side code generation flow is that, We first need to show this code as preview to users, And then users can proceed to create the referral with the given code, So even if we generate this on the server, it will still be sent from the post request in the end? @abeikverdi 

![image](https://github.com/user-attachments/assets/89107c38-7cc0-4fec-a74b-7999cd7799ba)
