### PR TITLE
Increase body parser limit to 2mb for announcements endpoint

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -11,6 +11,7 @@ const { checkStatus } = require('./init');
 const { API_HOST, CUSTOM_CSS } = require('./constants');
 const swaggerTools = require('swagger-tools');
 const cors = require('cors');
+const bodyParser = require('body-parser');
 
 checkStatus()
 	.then(() => {
@@ -56,6 +57,7 @@ checkStatus()
 
 		swaggerTools.initializeMiddleware(swaggerDoc, function (middleware) {
 
+			app.use('/v2/admin/announcements', bodyParser.json({ limit: '2mb' }));
 			app.use(middleware.swaggerMetadata());
 			if (process.env.NODE_ENV !== 'test') {
 				rateLimitMiddleware(app);


### PR DESCRIPTION
swagger-tools v0.10.4 hardcodes body-parser with default 100KB limit, causing PayloadTooLargeError on POST /v2/admin/announcements with larger payloads. Add a route-specific body-parser before swaggerMetadata so req.body is already set and swagger-tools skips its internal parser.